### PR TITLE
Fix: dubious supernova removal

### DIFF
--- a/stamp_classifier_step/strategies/ztf.py
+++ b/stamp_classifier_step/strategies/ztf.py
@@ -164,6 +164,8 @@ class ZTFStrategy(BaseStrategy):
             pd.DataFrame: Prediction-like data frame
         """
         return pd.DataFrame(
-            columns=["AGN", "SN", "VS", "asteroid", "bogus"], dtype=float,
-            data=data, index=idx
+            columns=["AGN", "SN", "VS", "asteroid", "bogus"],
+            dtype=float,
+            data=data,
+            index=idx,
         )


### PR DESCRIPTION
Criteria with `isdiffpos` compares against 0, but in ALeRCE the value can be 1 or -1